### PR TITLE
Disable textToolGroupButton

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ const App = () => {
           'viewControlsButton',
           'panToolButton',
           'textToolGroupButton',
+          'signatureToolButton',
         ],
       },
       viewer.current,

--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ const App = () => {
           'pageNavOverlay',
           'viewControlsButton',
           'panToolButton',
+          'textToolGroupButton',
         ],
       },
       viewer.current,


### PR DESCRIPTION
## Preamble

Videos won't have text that can be highlighted, or otherwise annotated,
thus users do not need text related tools available

Note from our discussion that we may want to disable this from [`webviewer-video`](https://github.com/XodoDocs/WebViewer-video), rather than in our sample.

## Screenshots

As of b65a699

### Before

![image](https://user-images.githubusercontent.com/16601729/85624522-e5450000-b61e-11ea-9956-31ad55365156.png)

### After

![image](https://user-images.githubusercontent.com/16601729/85624452-cc3c4f00-b61e-11ea-97fb-4db4cbfe58d8.png)
