### PR TITLE
Support null loadVideo for Internet Explorer check

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import WebViewer from '@pdftron/webviewer';
 import { initializeVideoViewer } from '@pdftron/webviewer-video';
 import './App.css';
@@ -7,6 +7,7 @@ const DOCUMENT_ID = 'video';
 
 const App = () => {
   const viewer = useRef(null);
+  const [ internetExplorerCheck, setInternetExplorerCheck ] = useState(false);
 
   // if using a class, equivalent of componentDidMount
   useEffect(() => {
@@ -35,6 +36,11 @@ const App = () => {
         instance,
         license,
       );
+
+      if (!loadVideo) {
+        setInternetExplorerCheck(true);
+        return;
+      }
 
       // Attaches the video player UI
       loadVideoUI();
@@ -117,6 +123,14 @@ const App = () => {
       });
     });
   }, []);
+
+  if (internetExplorerCheck) {
+    return (
+      <div>
+        WebViewer Video does not support Internet Explorer.
+      </div>
+    )
+  }
 
   return (
     <div className="App">

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,11 @@ const App = () => {
 
   // if using a class, equivalent of componentDidMount
   useEffect(() => {
+    if (window.document.documentMode) {
+      setInternetExplorerCheck(true);
+      return;
+    }
+
     WebViewer(
       {
         path: '/webviewer/lib',
@@ -36,11 +41,6 @@ const App = () => {
         instance,
         license,
       );
-
-      if (!loadVideo) {
-        setInternetExplorerCheck(true);
-        return;
-      }
 
       // Attaches the video player UI
       loadVideoUI();


### PR DESCRIPTION
## Preamble

This PR renders an appropriate message when `webviewer-video` detects Internet Explorer as the browser.

## Screenshots

### Internet Explorer 11
![image](https://user-images.githubusercontent.com/16601729/87481527-5e16f680-c5e4-11ea-9d0c-b8012a4e8c6f.png)

### Chrome
![image](https://user-images.githubusercontent.com/16601729/87481549-6cfda900-c5e4-11ea-8abe-c4a2019f2902.png)

### Firefox
![image](https://user-images.githubusercontent.com/16601729/87481622-90c0ef00-c5e4-11ea-9fa3-16d5f990c3c9.png)

### Edge (Chromium)
![image](https://user-images.githubusercontent.com/16601729/87481703-b6e68f00-c5e4-11ea-97bb-8fff9e59c984.png)

